### PR TITLE
fix(deps): bump postcss to >=8.5.18 (Dependabot alert #245)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7416,9 +7416,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -8071,9 +8071,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -8091,7 +8091,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "brace-expansion": "^2.1.2",
     "fast-uri": "^3.1.4",
     "flatted": "^3.4.2",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.18",
     "follow-redirects": "^1.16.0",
     "ip-address": "^10.1.1",
     "minimatch@^3.0.0": "3.1.5",


### PR DESCRIPTION
## Contexte

Corrige l'alerte Dependabot [#245](https://github.com/GaetanOff/Front-GaetanDev/security/dependabot/245).

- **Avis** : [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) — severité **high**
- **Paquet** : `postcss` (scope `development`, via `package-lock.json`)
- **Problème** : path traversal lors de l'auto-chargement de la source map précédente (`sourceMappingURL`), permettant la divulgation arbitraire de fichiers `.map`
- **Versions affectées** : `<= 8.5.17` — résolue en `8.5.18`

## Changements

- `overrides.postcss` : `^8.5.10` → `^8.5.18`
- `package-lock.json` : `postcss` 8.5.15 → 8.5.25, `nanoid` 3.3.15 → 3.3.17 (dépendance transitive de postcss)

## Vérification

- `npm run build` (production) passe — l'avertissement de budget de bundle initial est préexistant.
- `npm audit` ne remonte plus postcss. Il reste une alerte high indépendante sur `brace-expansion` (DoS), hors périmètre de cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
