### PR TITLE
fix(deps): bump brace-expansion to >=2.1.3 (GHSA-mh99-v99m-4gvg)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4215,9 +4215,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@babel/core": "^7.29.6",
     "@babel/helpers": "^7.26.10",
     "lodash": "^4.18.0",
-    "brace-expansion": "^2.1.2",
+    "brace-expansion": "^2.1.3",
     "fast-uri": "^3.1.4",
     "flatted": "^3.4.2",
     "postcss": "^8.5.18",


### PR DESCRIPTION
## Contexte

Corrige la dernière alerte high remontée par `npm audit`.

- **Avis** : [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) — severité **high**
- **Paquet** : `brace-expansion` (dev uniquement, transitif via `minimatch`)
- **Problème** : DoS par expansion non bornée, provoquant un crash du process par épuisement mémoire
- **Versions affectées** : `>= 2.0.0, < 2.1.3` — résolue en `2.1.3`

À noter : cette vulnérabilité n'apparaissait pas dans les alertes Dependabot du dépôt, seulement dans `npm audit`.

## Changements

- `overrides.brace-expansion` : `^2.1.2` → `^2.1.3`
- `package-lock.json` : `brace-expansion` 2.1.2 → 2.1.4 (dernier patch de la ligne 2.x ; dépendances inchangées, `balanced-match@^1.0.0`)

L'override `@isaacs/brace-expansion` (`^5.0.1`) n'est pas modifié : aucun paquet de l'arbre ne le résout, et la contrainte permet déjà de monter au-delà de 5.0.8 (version corrigée de la ligne 5.x).

## Vérification

- `npm ci` s'installe proprement et rapporte `found 0 vulnerabilities`.
- `npm run build` (production) passe — l'avertissement de budget de bundle initial est préexistant.

Le lockfile est édité en place plutôt que régénéré : sous Windows, `npm install` élague les entrées optionnelles Linux `@emnapi/core` et `@emnapi/runtime`, ce qui casse `npm ci` en CI (cf. #100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
