### PR TITLE
Merge develop into master — correctifs sécurité postcss & brace-expansion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7416,9 +7416,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -8071,9 +8071,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -8091,7 +8091,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4215,9 +4215,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "brace-expansion": "^2.1.2",
     "fast-uri": "^3.1.4",
     "flatted": "^3.4.2",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.18",
     "follow-redirects": "^1.16.0",
     "ip-address": "^10.1.1",
     "minimatch@^3.0.0": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@babel/core": "^7.29.6",
     "@babel/helpers": "^7.26.10",
     "lodash": "^4.18.0",
-    "brace-expansion": "^2.1.2",
+    "brace-expansion": "^2.1.3",
     "fast-uri": "^3.1.4",
     "flatted": "^3.4.2",
     "postcss": "^8.5.18",


### PR DESCRIPTION
## Contexte

Remonte sur `master` les deux correctifs de sécurité mergés dans `develop`.

| Paquet | Avis | Sévérité | Avant → Après | PR |
|---|---|---|---|---|
| `postcss` | [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) | high | 8.5.15 → 8.5.25 | #100 |
| `brace-expansion` | [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) | high | 2.1.2 → 2.1.4 | #101 |

- **postcss** : path traversal lors de l'auto-chargement de la source map précédente (`sourceMappingURL`), permettant la divulgation arbitraire de fichiers `.map`. Correspond à l'alerte Dependabot [#245](https://github.com/GaetanOff/Front-GaetanDev/security/dependabot/245). Corrigé en 8.5.18.
- **brace-expansion** : DoS par expansion non bornée provoquant un crash du process par épuisement mémoire. Corrigé en 2.1.3. Cette vulnérabilité n'apparaissait que dans `npm audit`, pas dans les alertes Dependabot.

Les deux paquets sont en scope `development` (transitifs) — aucun impact sur le bundle livré.

## Changements

Uniquement `package.json` et `package-lock.json` (12 insertions, 12 suppressions) :

- `overrides.postcss` : `^8.5.10` → `^8.5.18`
- `overrides.brace-expansion` : `^2.1.2` → `^2.1.3`
- lockfile : `postcss` 8.5.15 → 8.5.25, `nanoid` 3.3.15 → 3.3.17 (requis par postcss 8.5.25), `brace-expansion` 2.1.2 → 2.1.4

Aucun changement de code applicatif.

## Vérification

- `npm ci` s'installe proprement et rapporte `found 0 vulnerabilities`.
- `npm run build` (production) passe — l'avertissement de budget de bundle initial (531 kB) est préexistant.
- CI verte sur #100 et #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
